### PR TITLE
Fix bug in tree compressing

### DIFF
--- a/src/main/kotlin/astminer/parse/antlr/AntlrUtil.kt
+++ b/src/main/kotlin/astminer/parse/antlr/AntlrUtil.kt
@@ -62,12 +62,15 @@ fun compressTree(root: SimpleNode): SimpleNode {
                 root.getParent(),
                 child.getToken()
         )
-        compressedNode.setChildren(child.getChildren())
+        compressedNode.setChildren(child.getChildren().map {
+            SimpleNode(it.getTypeLabel(), compressedNode, it.getToken())
+        } )
         compressedNode
     } else {
         root.setChildren(root.getChildren().map { compressTree(it as SimpleNode) })
         root
     }
 }
+
 
 fun decompressTypeLabel(typeLabel: String) = typeLabel.split("|")

--- a/src/main/kotlin/astminer/parse/antlr/AntlrUtil.kt
+++ b/src/main/kotlin/astminer/parse/antlr/AntlrUtil.kt
@@ -62,9 +62,7 @@ fun compressTree(root: SimpleNode): SimpleNode {
                 root.getParent(),
                 child.getToken()
         )
-        compressedNode.setChildren(child.getChildren().map {
-            SimpleNode(it.getTypeLabel(), compressedNode, it.getToken())
-        } )
+        compressedNode.setChildren(child.getChildren())
         compressedNode
     } else {
         root.setChildren(root.getChildren().map { compressTree(it as SimpleNode) })

--- a/src/main/kotlin/astminer/parse/antlr/SimpleNode.kt
+++ b/src/main/kotlin/astminer/parse/antlr/SimpleNode.kt
@@ -2,13 +2,18 @@ package astminer.parse.antlr
 
 import astminer.common.model.Node
 
-class SimpleNode(private val typeLabel: String, private val parent: Node?, private var token: String?) : Node {
+class SimpleNode(private val typeLabel: String, private var parent: Node?, private var token: String?) : Node {
     private val metadata: MutableMap<String, Any> = HashMap()
 
     private var children: List<Node> = emptyList()
 
     fun setChildren(newChildren: List<Node>) {
         children = newChildren
+        children.forEach { (it as SimpleNode).setParent(this) }
+    }
+
+    fun setParent(newParent: Node?) {
+        parent = newParent
     }
 
     override fun getTypeLabel(): String {

--- a/src/main/kotlin/astminer/parse/antlr/SimpleNode.kt
+++ b/src/main/kotlin/astminer/parse/antlr/SimpleNode.kt
@@ -2,6 +2,7 @@ package astminer.parse.antlr
 
 import astminer.common.model.Node
 
+// TODO make immutable
 class SimpleNode(private val typeLabel: String, private var parent: Node?, private var token: String?) : Node {
     private val metadata: MutableMap<String, Any> = HashMap()
 

--- a/src/test/kotlin/astminer/parse/antlr/AntrlUtilTest.kt
+++ b/src/test/kotlin/astminer/parse/antlr/AntrlUtilTest.kt
@@ -1,0 +1,23 @@
+package astminer.parse.antlr
+
+import astminer.common.preOrder
+import astminer.parse.antlr.java.JavaParser
+import org.junit.Assert
+import org.junit.Test
+import java.io.File
+import java.io.FileInputStream
+
+class AntrlUtilTest {
+    @Test
+    fun compressTreeTest() {
+        val parser = JavaParser()
+        val file = File("testData/methodSplitting/testMethodSplitting.java")
+
+        val node = parser.parse(FileInputStream(file))
+        var errorNodeSize = 0
+        node?.preOrder()?.forEach { node ->
+            errorNodeSize += node.getChildren().filter { it.getParent() != node }.size
+        }
+        Assert.assertEquals("There should be no children with different parent", 0, errorNodeSize)
+    }
+}

--- a/src/test/kotlin/astminer/parse/antlr/AntrlUtilTest.kt
+++ b/src/test/kotlin/astminer/parse/antlr/AntrlUtilTest.kt
@@ -14,10 +14,10 @@ class AntrlUtilTest {
         val file = File("testData/methodSplitting/testMethodSplitting.java")
 
         val node = parser.parse(FileInputStream(file))
-        var errorNodeSize = 0
+        var adoptedNodesSize = 0
         node?.preOrder()?.forEach { node ->
-            errorNodeSize += node.getChildren().filter { it.getParent() != node }.size
+            adoptedNodesSize += node.getChildren().filter { it.getParent() != node }.size
         }
-        Assert.assertEquals("There should be no children with different parent", 0, errorNodeSize)
+        Assert.assertEquals("There should be no children with different parent", 0, adoptedNodesSize)
     }
 }


### PR DESCRIPTION
Setting children of a node does not change children's parents, so the child of node A could have had another parent node B. 
Fix it by setting the right parent’s nodes.
