### PR TITLE
Renaming in MethodInfo class for more general cases of usage

### DIFF
--- a/src/main/kotlin/astminer/common/model/TreeSplittingModel.kt
+++ b/src/main/kotlin/astminer/common/model/TreeSplittingModel.kt
@@ -11,13 +11,13 @@ interface TreeMethodSplitter<T : Node> {
 
 class MethodInfo<T : Node>(
         val method: MethodNode<T>,
-        val enclosingClass: ClassNode<T>,
+        val enclosingElement: ElementNode<T>,
         val methodParameters: List<ParameterNode<T>>
 ) {
     fun name() = method.name()
     fun returnType() = method.returnType()
 
-    fun className() = enclosingClass.name()
+    fun enclosingElementName() = enclosingElement.name()
 }
 
 class MethodNode<T : Node>(
@@ -29,7 +29,7 @@ class MethodNode<T : Node>(
     fun returnType() = returnTypeNode?.getToken()
 }
 
-class ClassNode<T : Node>(
+class ElementNode<T : Node>(
         val root: T?,
         val nameNode: T?
 ) {

--- a/src/main/kotlin/astminer/examples/AllJavaFiles.kt
+++ b/src/main/kotlin/astminer/examples/AllJavaFiles.kt
@@ -23,7 +23,7 @@ fun allJavaFiles() {
         JavaMethodSplitter().splitIntoMethods(node).forEach {
             println(it.name())
             println(it.returnType())
-            println(it.className())
+            println(it.enclosingElementName())
             it.methodParameters.forEach { parameters ->
                 println("${parameters.name()} ${parameters.returnType()}")
             }

--- a/src/main/kotlin/astminer/parse/antlr/java/JavaMethodSplitter.kt
+++ b/src/main/kotlin/astminer/parse/antlr/java/JavaMethodSplitter.kt
@@ -47,7 +47,7 @@ class JavaMethodSplitter : TreeMethodSplitter<SimpleNode> {
 
         return MethodInfo(
                 MethodNode(methodNode, methodReturnTypeNode, methodName),
-                ClassNode(classRoot, className),
+                ElementNode(classRoot, className),
                 parametersList
         )
     }

--- a/src/main/kotlin/astminer/parse/antlr/python/PythonMethodSplitter.kt
+++ b/src/main/kotlin/astminer/parse/antlr/python/PythonMethodSplitter.kt
@@ -45,7 +45,7 @@ class PythonMethodSplitter : TreeMethodSplitter<SimpleNode> {
 
         return MethodInfo(
                 MethodNode(methodNode, null, methodName),
-                ClassNode(classRoot, className),
+                ElementNode(classRoot, className),
                 parametersList
         )
     }

--- a/src/main/kotlin/astminer/parse/cpp/FuzzyMethodSplitter.kt
+++ b/src/main/kotlin/astminer/parse/cpp/FuzzyMethodSplitter.kt
@@ -44,7 +44,7 @@ class FuzzyMethodSplitter : TreeMethodSplitter<FuzzyNode> {
 
         return MethodInfo(
                 MethodNode(methodNode, methodReturnType, methodName),
-                ClassNode(classRoot, className),
+                ElementNode(classRoot, className),
                 parameterNodes
         )
     }

--- a/src/test/kotlin/astminer/parse/antlr/java/JavaMethodSplitterTest.kt
+++ b/src/test/kotlin/astminer/parse/antlr/java/JavaMethodSplitterTest.kt
@@ -61,14 +61,14 @@ class JavaMethodSplitterTest {
     fun testFunctionInClass() {
         val methodClass = methodInfos.find { it.name() == "functionInClass1"  }
         assertNotNull(methodClass)
-        assertEquals( "Class1", methodClass.className())
+        assertEquals( "Class1", methodClass.enclosingElementName())
     }
 
     @Test
     fun testFunctionInNestedClass() {
         val methodClass = methodInfos.find { it.name() == "functionInClass2"  }
         assertNotNull(methodClass)
-        assertEquals( "Class2", methodClass.className())
+        assertEquals( "Class2", methodClass.enclosingElementName())
     }
 
     @Test

--- a/src/test/kotlin/astminer/parse/antlr/python/PythonMethodSplitterTest.kt
+++ b/src/test/kotlin/astminer/parse/antlr/python/PythonMethodSplitterTest.kt
@@ -34,21 +34,21 @@ class PythonMethodSplitterTest {
     fun testFunctionNotInClass() {
         val methodClass = methodInfos.find { it.name() == "funWithNoClass"  }
         assertNotNull(methodClass)
-        assertNull(methodClass.enclosingClass.root)
+        assertNull(methodClass.enclosingElement.root)
     }
 
     @Test
     fun testFunctionInClass() {
         val methodClass = methodInfos.find { it.name() == "funInClass1"  }
         assertNotNull(methodClass)
-        assertEquals( "Class1", methodClass.className())
+        assertEquals( "Class1", methodClass.enclosingElementName())
     }
 
     @Test
     fun testFunctionInNestedClass() {
         val methodClass = methodInfos.find { it.name() == "funInClass2"  }
         assertNotNull(methodClass)
-        assertEquals( "Class2", methodClass.className())
+        assertEquals( "Class2", methodClass.enclosingElementName())
     }
 
     @Test

--- a/src/test/kotlin/astminer/parse/cpp/FuzzyMethodSplitterTest.kt
+++ b/src/test/kotlin/astminer/parse/cpp/FuzzyMethodSplitterTest.kt
@@ -62,21 +62,21 @@ class FuzzyMethodSplitterTest {
     fun testFunctionNotInClass() {
         val methodClass = methodInfos.find { it.name() == "functionWithNoClass"  }
         assertNotNull(methodClass)
-        assertNull(methodClass.enclosingClass.root)
+        assertNull(methodClass.enclosingElement.root)
     }
 
     @Test
     fun testFunctionInClass() {
         val methodClass = methodInfos.find { it.name() == "functionInClass1"  }
         assertNotNull(methodClass)
-        assertEquals( "Class1", methodClass.className())
+        assertEquals( "Class1", methodClass.enclosingElementName())
     }
 
     @Test
     fun testFunctionInNestedClass() {
         val methodClass = methodInfos.find { it.name() == "functionInClass2"  }
         assertNotNull(methodClass)
-        assertEquals( "Class2", methodClass.className())
+        assertEquals( "Class2", methodClass.enclosingElementName())
     }
 
     @Test


### PR DESCRIPTION
Suggest new names for `enclosingClass` and `ClassNode`  in order to get rid of the "Class" mention and thereby be able to use them in more general cases (for example, in JavaScript method splitting)